### PR TITLE
Handle reactive checks returning running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "forester-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Workflow framework based on the behavior trees"
 authors = ["BorisZhguchev <zhguchev@hotmail.com>"]
 homepage = "https://github.com/besok/forester"
 repository = "https://github.com/besok/forester"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license-file = "LICENSE"
 

--- a/docs/src/falls.md
+++ b/docs/src/falls.md
@@ -76,6 +76,8 @@ root main {
 The node `action` returns `running` and the whole sequence returns `running`
 but on the next tick it starts from the node `needs_to_charge` again.
 
-`r_fallback` will halt the `running` child to allow a graceful shutdown if a prior child changes from `failure` to `success`. In the above example, if `needs_to_change` returned `success` on the second tick then `action` would be halted before `r_fallback` returned `success` itself.
+`r_fallback` will halt the `running` child to allow a graceful shutdown if a prior child changes from `failure` to `success` or `running`. In the above example, if `needs_to_change` returned `success` on the second tick then `action` would be halted before `r_fallback` returned `success` itself.
+
+If `needs_to_charge` returned `running` on the second tick then `action` would also be halted, before potentially being restarted if `needs_to_charge` then returned `failure` again. Limiting the `r_fallback` node to a single `running` child avoids undefined behaviour in nodes that assume they are being run synchronously.
 
 Halting must be performed as quickly as possible. Note that currently only build-in flow, built-in decorator and sync action nodes are halted, async and remote actions are not.

--- a/docs/src/seq.md
+++ b/docs/src/seq.md
@@ -98,6 +98,8 @@ root main {
 The node `perform_action` returns `running` and the whole sequence returns `running`
 but on the next tick it starts from the node `store` again.
 
-`r_sequence` will halt the `running` child to allow a graceful shutdown if a prior child changes from `success` to `failure`. In the above example, if `store` returned `failure` on the second tick then `perform_action` would be halted before `r_sequence` returned `failure` itself.
+`r_sequence` will halt the `running` child to allow a graceful shutdown if a prior child changes from `success` to `failure` or `running`. In the above example, if `store` returned `failure` on the second tick then `perform_action` would be halted before `r_sequence` returned `failure` itself.
+
+If `store` returned `running` on the second tick then `perform_action` would also be halted, before potentially being restarted if `store` then returned `success` again. Limiting the `r_sequence` node to a single `running` child avoids undefined behaviour in nodes that assume they are being run synchronously.
 
 Halting must be performed as quickly as possible. Note that currently only build-in flow, built-in decorator and sync action nodes are halted, async and remote actions are not.

--- a/src/tests/flow.rs
+++ b/src/tests/flow.rs
@@ -323,6 +323,44 @@ fn r_sequence_halt_on_interrupt() {
 }
 
 #[test]
+fn r_sequence_halted_by_running() {
+    // See comment in the tree file for what this is testing.
+    let mut fb = fb("flow/r_sequence_halted_by_running");
+
+    fb.register_sync_action(
+        "incr",
+        GenerateData::new(|v| RtValue::int(v.as_int().unwrap_or(0) + 1)),
+    );
+
+    let mut f = fb.build().unwrap();
+    assert_eq!(f.run(), Ok(TickResult::success()));
+
+    let a =
+        f.bb.lock()
+            .unwrap()
+            .get("a".to_string())
+            .ok()
+            .flatten()
+            .unwrap()
+            .clone()
+            .as_int()
+            .unwrap();
+    assert_eq!(a, 10);
+
+    let b =
+        f.bb.lock()
+            .unwrap()
+            .get("b".to_string())
+            .ok()
+            .flatten()
+            .unwrap()
+            .clone()
+            .as_int()
+            .unwrap();
+    assert_eq!(b, 9);
+}
+
+#[test]
 fn fallback() {
     let mut fb = fb("flow/fallback");
 
@@ -487,6 +525,44 @@ fn r_fallback_halt_on_interrupt() {
             .as_int()
             .unwrap();
     assert_eq!(x, 7)
+}
+
+#[test]
+fn r_fallback_halted_by_running() {
+    // See comment in the tree file for what this is testing.
+    let mut fb = fb("flow/r_fallback_halted_by_running");
+
+    fb.register_sync_action(
+        "incr",
+        GenerateData::new(|v| RtValue::int(v.as_int().unwrap_or(0) + 1)),
+    );
+
+    let mut f = fb.build().unwrap();
+    assert_eq!(f.run(), Ok(TickResult::success()));
+
+    let a =
+        f.bb.lock()
+            .unwrap()
+            .get("a".to_string())
+            .ok()
+            .flatten()
+            .unwrap()
+            .clone()
+            .as_int()
+            .unwrap();
+    assert_eq!(a, 10);
+
+    let b =
+        f.bb.lock()
+            .unwrap()
+            .get("b".to_string())
+            .ok()
+            .flatten()
+            .unwrap()
+            .clone()
+            .as_int()
+            .unwrap();
+    assert_eq!(b, 9);
 }
 
 #[test]

--- a/tree/tests/flow/r_fallback_halted_by_running/main.tree
+++ b/tree/tests/flow/r_fallback_halted_by_running/main.tree
@@ -1,0 +1,15 @@
+import "std::actions"
+impl incr(key:string,default:num);
+
+// We're testing a reactively-checked child returning running will halt any other running children.
+// If a running child does halt other running children, repeat(5) will be reset and b will be incremented a total of 9 times. If no halt is called, b will only be incremented 5 times.
+root main repeat(2) sequence {
+    r_fallback {
+        sequence {
+            incr("a",0)
+            equal(a,5)
+            repeat(2) success()
+        }
+        repeat(5) incr("b",0)
+    }
+}

--- a/tree/tests/flow/r_fallback_halted_by_running/main.tree
+++ b/tree/tests/flow/r_fallback_halted_by_running/main.tree
@@ -3,13 +3,11 @@ impl incr(key:string,default:num);
 
 // We're testing that a reactively-checked child returning running will halt any other running children.
 // If a running child does halt other running children, repeat(5) will be reset and b will be incremented a total of 9 times. If no halt is called, b will only be incremented 5 times.
-root main repeat(2) sequence {
-    r_fallback {
-        sequence {
-            incr("a",0)
-            equal(a,5)
-            repeat(2) success()
-        }
-        repeat(5) incr("b",0)
+root main repeat(2) r_fallback {
+    sequence {
+        incr("a",0)
+        equal(a,5)
+        repeat(2) success()
     }
+    repeat(5) incr("b",0)
 }

--- a/tree/tests/flow/r_fallback_halted_by_running/main.tree
+++ b/tree/tests/flow/r_fallback_halted_by_running/main.tree
@@ -1,7 +1,7 @@
 import "std::actions"
 impl incr(key:string,default:num);
 
-// We're testing a reactively-checked child returning running will halt any other running children.
+// We're testing that a reactively-checked child returning running will halt any other running children.
 // If a running child does halt other running children, repeat(5) will be reset and b will be incremented a total of 9 times. If no halt is called, b will only be incremented 5 times.
 root main repeat(2) sequence {
     r_fallback {

--- a/tree/tests/flow/r_sequence_halted_by_running/main.tree
+++ b/tree/tests/flow/r_sequence_halted_by_running/main.tree
@@ -1,7 +1,7 @@
 import "std::actions"
 impl incr(key:string,default:num);
 
-// We're testing taht a reactively-checked child returning running will halt any other running children.
+// We're testing that a reactively-checked child returning running will halt any other running children.
 // If a running child does halt other running children, repeat(5) will be reset and b will be incremented a total of 9 times. If no halt is called, b will only be incremented 5 times.
 root main retry(2) r_sequence {
     fallback {

--- a/tree/tests/flow/r_sequence_halted_by_running/main.tree
+++ b/tree/tests/flow/r_sequence_halted_by_running/main.tree
@@ -1,0 +1,13 @@
+import "std::actions"
+impl incr(key:string,default:num);
+
+// We're testing taht a reactively-checked child returning running will halt any other running children.
+// If a running child does halt other running children, repeat(5) will be reset and b will be incremented a total of 9 times. If no halt is called, b will only be incremented 5 times.
+root main retry(2) r_sequence {
+    fallback {
+        inverter incr("a",0)
+        inverter equal(a,5)
+        retry(2) fail_empty()
+    }
+    repeat(5) incr("b",0)
+}


### PR DESCRIPTION
This PR fixes a bug where a reactively-checked child returning `running` would override the `r_fallback` or `r_sequence`'s memory of any other running child.

This leads to that other running child not being halted, and so restarting from halfway through if re-entered later on.

The chosen new behaviour of only allowing a single running child and halting any other children was chosen because:

1. It avoids all the edge cases involved with having two `running` nodes inside the same `r_sequence` (effectively turning `r_sequence` into a parallel node)
2. It's the same default behaviour as BehaviourTree.CPP, so hopefully it's intuitive for anyone coming from that library